### PR TITLE
Preserve securitySchemes when unused

### DIFF
--- a/unused.go
+++ b/unused.go
@@ -56,7 +56,6 @@ func CleanUnused(rdoc *interface{}) error {
 				`/components/examples`,
 				`/components/requestBodies`,
 				`/components/headers`,
-				`/components/securitySchemes`,
 				`/components/links`,
 				`/components/callbacks`,
 			}


### PR DESCRIPTION
Currently `securitySchemes` are deleted because there are no `$ref` pointers to them. That's intended since that's how they work.

Solves #10 