### PR TITLE
doc: add manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 
 binary = openapi-preprocessor
+man = $(binary).1
 go = GO111MODULE=on go
 # Go-modules versionning style
 version = $(shell TZ=UTC git log -1 '--date=format-local:%Y%m%d%H%M%S' --abbrev=12 '--pretty=tformat:v0.0.0-%cd-%h' go.mod $(shell $(go) list -f '{{$$Dir := .Dir}}{{range .GoFiles}}{{$$Dir}}/{{.}} {{end}}' ./... ))
 
-all: $(binary)
+all: $(binary) $(man)
 
 .PHONY: all test clean install .FORCE
 
@@ -23,6 +24,9 @@ $(binary): .FORCE
 upgrade-jsonptr: ../jsonptr/Makefile
 	$(shell $(MAKE) -C ../jsonptr go-get)
 	$(go) mod tidy
+
+$(man): main.go
+	go generate
 
 install:
 	$(go) install -ldflags "-X main.version=@(#)$(version)"

--- a/main.go
+++ b/main.go
@@ -1,3 +1,30 @@
+// Rebuild openapi-preprocessor.1 from godoc:
+//go:generate go run github.com/lufia/godoc2man@v0.0.0-20241209075419-fff9a8c99089
+
+/*
+openapi-preprocessor process keywords in an extended version of an OpenAPI specification.
+
+# Synopsis
+
+	openapi-preprocessor [-c] [-compact-output] [-debug=trace] <spec[.yaml|.json]>
+
+	openapi-preprocessor -version
+
+# Options
+
+  - -c compact JSON output
+  - -debug=trace show trace of how the document is traversed
+
+# Preprocessor directives
+
+See [full documentation] online.
+
+# Authors
+
+  - Olivier Mengué <dolmen@cpan.org>
+
+[full documentation]: https://github.com/dolmen-go/openapi-preprocessor/blob/master/README.md#keywords
+*/
 package main
 
 import (

--- a/openapi-preprocessor.1
+++ b/openapi-preprocessor.1
@@ -1,0 +1,30 @@
+.TH openapi-preprocessor 1
+.SH NAME
+openapi-preprocessor \- process keywords in an extended version of an OpenAPI specification.
+.SH OVERVIEW
+.PP
+openapi\-preprocessor process keywords in an extended version of an OpenAPI specification.
+.SH SYNOPSIS
+.PP
+.EX
+.in +4n
+openapi\-preprocessor [\-c] [\-compact\-output] [\-debug=trace] <spec[.yaml|.json]>
+
+openapi\-preprocessor \-version
+.in
+.EE
+.SH OPTIONS
+.IP \(bu 4
+\-c compact JSON output
+.IP \(bu 4
+\-debug=trace show trace of how the document is traversed
+.SH PREPROCESSOR DIRECTIVES
+.PP
+See
+.UR "https://github.com/dolmen\-go/openapi\-preprocessor/blob/master/README.md#keywords"
+full documentation
+.UE
+online.
+.SH AUTHORS
+.IP \(bu 4
+Olivier Mengué <dolmen@cpan.org>


### PR DESCRIPTION
Add manpage generated from Go doc using [godoc2man](https://github.com/lufia/godoc2man).